### PR TITLE
Update npm publish configuration for provenance and public access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,9 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
 
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm publish
+      - run: npm publish --provenance --access public
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
Updated the npm publish workflow to include provenance attestation and explicitly set package access to public, while removing the redundant registry URL configuration.

## Key Changes
- Removed explicit `registry-url` configuration from the Node.js setup step (npmjs.org is the default registry)
- Updated `npm publish` command to include `--provenance` flag for supply chain security attestation
- Added `--access public` flag to ensure the package is published with public access

## Implementation Details
These changes improve the security and clarity of the release workflow:
- **Provenance**: The `--provenance` flag enables npm to generate and publish provenance attestations, allowing consumers to verify the package's build and publication integrity
- **Public Access**: Explicitly setting `--access public` removes ambiguity about package visibility and ensures consistent behavior across releases
- **Simplified Configuration**: Removing the hardcoded registry URL reduces configuration noise since npmjs.org is the default registry for npm publish

https://claude.ai/code/session_019xNwxu6gPktgwfES5TnhY5